### PR TITLE
Fix battery level reporting for vacuum

### DIFF
--- a/packages/backend/src/matter/behaviors/power-source-server.ts
+++ b/packages/backend/src/matter/behaviors/power-source-server.ts
@@ -19,9 +19,12 @@ class PowerSourceServerBase extends Base {
   }
 
   private update(entity: HomeAssistantEntityInformation) {
-    const percent = this.state.config.getBatteryPercent(entity.state, this.agent);
-    applyPatchState(this.state as any, {
-      batPercentRemaining: percent == null ? null : Math.round(percent * 2),
+    const percent = this.state.config.getBatteryPercent(
+      entity.state,
+      this.agent,
+    );
+    applyPatchState<PowerSourceServerBase.State>(this.state, {
+      batPercentRemaining: percent == null ? null : Math.round(percent * 200),
     });
   }
 }


### PR DESCRIPTION
## Summary
- properly round battery percent remaining for vacuums
- type power source update for lint compliance

## Testing
- `pnpm vitest run`
- `pnpm lint` *(fails: formatter changes required in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684d709db0bc83269366fcea7edc3050